### PR TITLE
Configurable log level

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -24,15 +25,26 @@ import (
 	"jinr.ru/greenlab/go-adc/cmd/control"
 	"jinr.ru/greenlab/go-adc/cmd/discover"
 	"jinr.ru/greenlab/go-adc/cmd/mstream"
+	pkgconfig "jinr.ru/greenlab/go-adc/pkg/config"
 	"jinr.ru/greenlab/go-adc/pkg/log"
 )
 
+const (
+	LogLevelOptionName = "log-level"
+)
+
 func NewRootCommand(out io.Writer) *cobra.Command {
+	var logLevel string
+	cfg := pkgconfig.NewDefaultConfig()
+	cfg.Load()
 	cmd := &cobra.Command{
 		Use:   "go-adc",
 		Short: "Tool to work with ADC64 devices",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			log.Init(cmd.ErrOrStderr())
+			if logLevel != "" {
+				cfg.LogLevel = logLevel
+			}
+			log.Init(cmd.ErrOrStderr(), cfg.LogLevel)
 		},
 	}
 	cmd.SetOut(out)
@@ -41,5 +53,6 @@ func NewRootCommand(out io.Writer) *cobra.Command {
 	cmd.AddCommand(discover.NewCommand())
 	cmd.AddCommand(mstream.NewCommand())
 	cmd.AddCommand(completion.NewCommand())
+	cmd.PersistentFlags().StringVar(&logLevel, LogLevelOptionName, "", fmt.Sprintf("Log level. %s", log.HelpLevels))
 	return cmd
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,10 +8,10 @@ services:
     - /home/pmtlab/tmp:/data
     - /home/pmtlab/.go-adc:/root/.go-adc
     network_mode: host
-    command: go-adc mstream start
+    command: go-adc --log-level debug mstream start
   control-server:
     <<: *mstream-server
-    command: go-adc control start
+    command: go-adc --log-level debug control start
   discover-server:
     <<: *mstream-server
-    command: go-adc discover start
+    command: go-adc --log-level debug discover start

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type Device struct {
 }
 
 type Config struct {
+	LogLevel      string    `json:"logLevel,omitempty"`
 	DiscoverIP    *net.IP   `json:"discoverIP,omitempty"`
 	DiscoverIface string    `json:"discoverIface,omitempty"`
 	IP            *net.IP   `json:"ip,omitempty"`
@@ -118,6 +119,7 @@ func NewDefaultConfig() *Config {
 	ip := net.ParseIP(DefaultIP)
 
 	return &Config{
+		LogLevel:      DefaultLogLevel,
 		DiscoverIP:    &discoverIP,
 		DiscoverIface: DefaultDiscoverIface,
 		IP:            &ip,

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -22,4 +22,5 @@ const (
 	DefaultDiscoverIP    = "239.192.1.1"
 	DefaultDiscoverIface = "eth0"
 	DefaultIP            = "192.168.1.100"
+	DefaultLogLevel      = "info"
 )

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,6 +15,7 @@
 package log
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -24,12 +25,12 @@ import (
 type LogLevel int
 
 const (
-	LogPrefix       = "[go-adc] "
-	ErrorPrefix     = "[error] "
-	WarningPrefix   = "[warn] "
-	InfoPrefix      = "[info] "
-	DebugPrefix     = "[debug] "
-	DefaultLogLevel = InfoLevel
+	LogPrefix     = "[go-adc] "
+	ErrorPrefix   = "[error] "
+	WarningPrefix = "[warn] "
+	InfoPrefix    = "[info] "
+	DebugPrefix   = "[debug] "
+	HelpLevels    = "Must be one of: error, warning, info, debug."
 )
 
 const (
@@ -45,12 +46,30 @@ type Logger struct {
 }
 
 var logger = &Logger{
-	level:  DefaultLogLevel,
+	level:  InfoLevel,
 	Logger: log.New(os.Stderr, LogPrefix, log.LstdFlags),
 }
 
-func Init(out io.Writer) {
+func SetLevel(strLevel string) error {
+	levelMapping := map[string]LogLevel{
+		"error":   ErrorLevel,
+		"warning": WarningLevel,
+		"info":    InfoLevel,
+		"debug":   DebugLevel,
+	}
+	level, ok := levelMapping[strLevel]
+	if !ok {
+		return errors.New("Wrong log level. " + HelpLevels)
+	}
+	logger.level = level
+	return nil
+}
+
+func Init(out io.Writer, strLevel string) {
 	logger.SetOutput(out)
+	if err := SetLevel(strLevel); err != nil {
+		panic(err)
+	}
 }
 
 func Error(format string, v ...interface{}) {

--- a/pkg/srv/control/api.go
+++ b/pkg/srv/control/api.go
@@ -125,7 +125,7 @@ type ApiServer struct {
 var _ ifc.ApiServer = &ApiServer{}
 
 func NewApiServer(ctx context.Context, cfg *config.Config, ctrl ifc.ControlServer) (ifc.ApiServer, error) {
-	log.Debug("Initializing API server with address: %s port: %d", cfg.IP, ApiPort)
+	log.Info("Initializing API server with address: %s port: %d", cfg.IP, ApiPort)
 
 	s := &ApiServer{
 		Context: ctx,
@@ -170,7 +170,7 @@ func (s *ApiServer) regReadAllHex(device string) ([]*RegHex, error) {
 
 // Start
 func (s *ApiServer) Run() error {
-	log.Debug("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
+	log.Info("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
 	s.configureRouter()
 	httpServer := &http.Server{
 		Handler: s.Router,

--- a/pkg/srv/discover/api.go
+++ b/pkg/srv/discover/api.go
@@ -65,7 +65,7 @@ type ApiServer struct {
 }
 
 func NewApiServer(ctx context.Context, cfg *config.Config, discover *DiscoverServer) (*ApiServer, error) {
-	log.Debug("Initializing API server with address: %s port: %d", cfg.IP, ApiPort)
+	log.Info("Initializing API server with address: %s port: %d", cfg.IP, ApiPort)
 
 	s := &ApiServer{
 		Context:  ctx,
@@ -77,7 +77,7 @@ func NewApiServer(ctx context.Context, cfg *config.Config, discover *DiscoverSer
 
 // Start
 func (s *ApiServer) Run() error {
-	log.Debug("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
+	log.Info("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
 	s.configureRouter()
 	httpServer := &http.Server{
 		Handler: s.Router,

--- a/pkg/srv/mstream/api.go
+++ b/pkg/srv/mstream/api.go
@@ -100,7 +100,7 @@ func NewApiServer(ctx context.Context, cfg *config.Config, mstream *MStreamServe
 
 // Start
 func (s *ApiServer) Run() error {
-	log.Debug("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
+	log.Info("Starting API server: address: %s port: %d", s.Config.IP, ApiPort)
 	s.configureRouter()
 	httpServer := &http.Server{
 		Handler: s.Router,


### PR DESCRIPTION
The patch makes it possible to define log
level either in the config file ~/.go-adc/config
or via CLI option --log-level