### PR TITLE
Update device

### DIFF
--- a/pkg/device/ifc/device.go
+++ b/pkg/device/ifc/device.go
@@ -14,7 +14,11 @@
 
 package ifc
 
-import "jinr.ru/greenlab/go-adc/pkg/layers"
+import (
+	"net"
+
+	"jinr.ru/greenlab/go-adc/pkg/layers"
+)
 
 type Device interface {
 	MStreamStart() error
@@ -45,4 +49,7 @@ type Device interface {
 	IsRunning() (bool, error)
 
 	UpdateReg(reg *layers.Reg) error
+
+	GetName() string
+	GetIP() *net.IP
 }

--- a/pkg/srv/control/ifc/state.go
+++ b/pkg/srv/control/ifc/state.go
@@ -20,6 +20,7 @@ type State interface {
 	SetReg(reg *layers.Reg, deviceName string) error
 	GetReg(addr uint16, deviceName string) (*layers.Reg, error)
 	GetRegAll(deviceName string) ([]*layers.Reg, error)
+	GetRegs(deviceName string, regsToGet []uint16) ([]*layers.Reg, error)
 	CreateBucket(name string) error
 	Close()
 }


### PR DESCRIPTION
- Remove unused fields
- Add two new functions GetName and GetIP to make it possible to use device interface in control server instead of device struct
- Use state.GetRegs instead of state.GetRegAll to request explicit list of registers and decrease control traffic